### PR TITLE
Militarised miners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 /_maps/templates.dm
 /config
 config/config.txt
+config/admins.txt

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -218,47 +218,6 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 6
-	STR.max_w_class = WEIGHT_CLASS_BULKY
-	STR.max_combined_w_class = 20
-	STR.can_hold = typecacheof(list(
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/multitool,
-		/obj/item/flashlight,
-		/obj/item/stack/cable_coil,
-		/obj/item/analyzer,
-		/obj/item/extinguisher/mini,
-		/obj/item/radio,
-		/obj/item/clothing/gloves,
-		/obj/item/resonator,
-		/obj/item/mining_scanner,
-		/obj/item/pickaxe,
-		/obj/item/stack/sheet/animalhide,
-		/obj/item/stack/sheet/sinew,
-		/obj/item/stack/sheet/bone,
-		/obj/item/lighter,
-		/obj/item/storage/fancy/cigarettes,
-		/obj/item/reagent_containers/food/drinks/bottle,
-		/obj/item/stack/medical,
-		/obj/item/kitchen/knife,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/gps,
-		/obj/item/storage/bag/ore,
-		/obj/item/survivalcapsule,
-		/obj/item/t_scanner/adv_mining_scanner,
-		/obj/item/reagent_containers/pill,
-		/obj/item/storage/pill_bottle,
-		/obj/item/stack/ore,
-		/obj/item/reagent_containers/food/drinks,
-		/obj/item/organ/regenerative_core,
-		/obj/item/wormhole_jaunter,
-		/obj/item/storage/bag/plants,
-		/obj/item/stack/marker_beacon
-		))
-
 
 /obj/item/storage/belt/mining/vendor
 	contents = newlist(/obj/item/survivalcapsule)

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -10,8 +10,8 @@
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	hoodtype = /obj/item/clothing/head/hooded/explorer
-	armor = list("melee" = 35, "bullet" = 20, "laser" = 10, "energy" = 10, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
-	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/pickaxe)
+	armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = 50, "bio" = 100, "rad" = 65, "fire" = 65, "acid" = 65)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/pickaxe, /obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/restraints/handcuffs, /obj/item/stock_parts/cell)
 	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/head/hooded/explorer
@@ -22,7 +22,7 @@
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
-	armor = list("melee" = 30, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
+	armor = list("melee" = 45, "bullet" = 45, "laser" = 45, "energy" = 45, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 50, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/suit/hooded/explorer/Initialize()

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -1,8 +1,8 @@
 /**********************Mining Equipment Vendor**************************/
 
 /obj/machinery/mineral/equipment_vendor
-	name = "mining equipment vendor"
-	desc = "An equipment vendor for miners, points collected at an ore redemption machine can be spent here."
+	name = "exploration equipment vendor"
+	desc = "An equipment vendor for miners and adventurers, points collected at an ore redemption machine can be spent here."
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "mining"
 	density = TRUE
@@ -16,21 +16,29 @@
 		new /datum/data/mining_equipment("Whiskey",						/obj/item/reagent_containers/food/drinks/bottle/whiskey,			100),
 		new /datum/data/mining_equipment("Absinthe",					/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,	100),
 		new /datum/data/mining_equipment("Cigar",						/obj/item/clothing/mask/cigarette/cigar/havana,						150),
-		new /datum/data/mining_equipment("Soap",						/obj/item/soap,											200),
-		new /datum/data/mining_equipment("Laser Pointer",				/obj/item/laser_pointer,											300),
+		new /datum/data/mining_equipment("Soap",						/obj/item/soap,														200),
+		new /datum/data/mining_equipment("Basic Vault-Tec C.A.M.P.",	/obj/item/survivalcapsule,											400),
+		new /datum/data/mining_equipment("Geiger counter",				/obj/item/geiger_counter,											150),
 		new /datum/data/mining_equipment("Explorer's Webbing",			/obj/item/storage/belt/mining,										500),
 		new /datum/data/mining_equipment("Point Transfer Card",			/obj/item/card/mining_point_card,									500),
 		new /datum/data/mining_equipment("Kinetic Crusher",				/obj/item/twohanded/required/kinetic_crusher,						750),
 		new /datum/data/mining_equipment("Kinetic Accelerator",			/obj/item/gun/energy/kinetic_accelerator,							750),
+		new /datum/data/mining_equipment("10-mm pistol",				/obj/item/gun/ballistic/automatic/pistol/n99,						750),
+		new /datum/data/mining_equipment("10-mm SMG",					/obj/item/gun/ballistic/automatic/smg10mm,							1250),
+		new /datum/data/mining_equipment("10-mm pistol mag",			/obj/item/ammo_box/magazine/m10mm_adv,								250),
+		new /datum/data/mining_equipment("10-mm SMG mag",				/obj/item/ammo_box/magazine/m10mm_auto,								300),
+		new /datum/data/mining_equipment("10-mm ammo box",				/obj/item/ammo_box/c10mm,											500),
+		new /datum/data/mining_equipment("10-mm ammo box (HP)",			/obj/item/ammo_box/c10mm/jhp,										750),
+		new /datum/data/mining_equipment("10-mm ammo box (AP)",			/obj/item/ammo_box/c10mm/ap,										1000),
+		new /datum/data/mining_equipment("Laser pistol",				/obj/item/gun/energy/laser/pistol,									750),
+		new /datum/data/mining_equipment("Energy cell",					/obj/item/stock_parts/cell/ammo/ec,									500),
+		new /datum/data/mining_equipment("Stimpak",						/obj/item/reagent_containers/hypospray/medipen/stimpak,				500),
+		new /datum/data/mining_equipment("MRE",							/obj/item/reagent_containers/food/snacks/f13/mre,					150),
+		new /datum/data/mining_equipment("Flask",						/obj/item/reagent_containers/food/drinks/flask/vault113,			150),
 		new /datum/data/mining_equipment("Advanced Scanner",			/obj/item/t_scanner/adv_mining_scanner,								800),
 		new /datum/data/mining_equipment("Resonator",					/obj/item/resonator,												800),
-		new /datum/data/mining_equipment("Lazarus Injector",			/obj/item/lazarus_injector,											1000),
-		new /datum/data/mining_equipment("Silver Pickaxe",				/obj/item/pickaxe/silver,											1000),
 		new /datum/data/mining_equipment("Mining Conscription Kit",		/obj/item/storage/backpack/duffelbag/mining_conscript,				1000),
-//		new /datum/data/mining_equipment("Mining Hardsuit",				/obj/item/clothing/suit/space/hardsuit/mining,						2000),
-		new /datum/data/mining_equipment("Diamond Pickaxe",				/obj/item/pickaxe/diamond,											2000),
-		new /datum/data/mining_equipment("Super Resonator",				/obj/item/resonator/upgraded,										2500),
-		new /datum/data/mining_equipment("Jump Boots",					/obj/item/clothing/shoes/bhop,										2500),
+		new /datum/data/mining_equipment("Jump Boots",					/obj/item/clothing/shoes/bhop,										3000),
 		new /datum/data/mining_equipment("KA White Tracer Rounds",		/obj/item/borg/upgrade/modkit/tracer,								100),
 		new /datum/data/mining_equipment("KA Adjustable Tracer Rounds",	/obj/item/borg/upgrade/modkit/tracer/adjustable,					150),
 		new /datum/data/mining_equipment("KA Super Chassis",			/obj/item/borg/upgrade/modkit/chassis_mod,							250),
@@ -255,14 +263,17 @@
 		qdel(src)
 
 /obj/item/storage/backpack/duffelbag/mining_conscript
-	name = "mining conscription kit"
-	desc = "A kit containing everything a crewmember needs to support a shaft miner in the field."
+	name = "explorer conscription kit"
+	desc = "A kit containing everything a crewmember needs to commence exploration out in the Wastes."
 
 /obj/item/storage/backpack/duffelbag/mining_conscript/PopulateContents()
 	new /obj/item/pickaxe/mini(src)
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
 	new /obj/item/storage/bag/ore(src)
+	new /obj/item/clothing/gloves/color/black(src)
+	new /obj/item/clothing/shoes/workboots/mining(src)
+	new /obj/item/clothing/under/rank/miner/lavaland
 	new /obj/item/clothing/suit/hooded/explorer(src)
 	new /obj/item/encryptionkey/headset_cargo(src)
 	new /obj/item/clothing/mask/gas/explorer(src)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -273,7 +273,7 @@
 	new /obj/item/storage/bag/ore(src)
 	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/clothing/shoes/workboots/mining(src)
-	new /obj/item/clothing/under/rank/miner/lavaland
+	new /obj/item/clothing/under/rank/miner/lavaland(src)
 	new /obj/item/clothing/suit/hooded/explorer(src)
 	new /obj/item/encryptionkey/headset_cargo(src)
 	new /obj/item/clothing/mask/gas/explorer(src)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
"Улучшает" содержимое шахтовендора, добавляя в него огнестрел и различные полезные для выходцев из Убежища/Братства вещи.
Баффает костюм и разгрузку исследователя, добавляя первому резистов и возможность переноса пушек, второму снятие ограничений переносимых вещей.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Шахтёрский костюм до этого был также улучшен на прошлом билде и был довольно эффективным набором брони, а добавление огнестрела в раздатчик позволит сэкономить ресурсы РнД Убежища/Братства.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Никак, так как это, в основном, смена переменных. Купил всё вышеперечисленное на локалке, пострелял по броне.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/65255980/93021742-e4a87e00-f5fd-11ea-9f13-fe7d6c4f2117.png)
![image](https://user-images.githubusercontent.com/65255980/93021893-07876200-f5ff-11ea-99d8-9091812b6869.png)

## Changelog (necessary)
:cl:
add: Added new things to the mining (Now exploration) vendor. Guns, food, ammo, cool stuff.
tweak: Explorer's webbing's now capable of holding non-mining gear, yet the maximum size has been reduced.
balance: Explorer suit buffed.
code: changed some code.
/:cl:
